### PR TITLE
Demos for Checkbox, FAB

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Elm bindings to
 ## Build instructions
 
 ```sh
-$ git clone github.com:aforemny/elm-mwc.git
-$ cd elm-mwc
-$ git submodule update --init
+$ git clone --recursive github.com:aforemny/elm-mwc.git
+$ npm i
+$ make
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ Elm bindings to
 
 ```sh
 $ git clone --recursive github.com:aforemny/elm-mwc.git
-$ npm i
-$ make
 ```
 
 
@@ -28,6 +26,7 @@ $ open http://localhost:8081/page.html
 ### Other Linux
 
 ```sh
+$ npm i
 $ make
 $ (cd material-components-web-components && npm run dev)
 $ ^C-c # terminate it

--- a/demo/Demo/Button.elm
+++ b/demo/Demo/Button.elm
@@ -1,4 +1,4 @@
-module Button exposing (..)
+module Demo.Button exposing (..)
 
 import Html exposing (Html, text)
 import Html.Attributes as Html

--- a/demo/Demo/Card.elm
+++ b/demo/Demo/Card.elm
@@ -1,4 +1,4 @@
-module Card exposing (..)
+module Demo.Card exposing (..)
 
 import Html exposing (Html, text)
 import Html.Attributes as Html

--- a/demo/Demo/Checkbox.elm
+++ b/demo/Demo/Checkbox.elm
@@ -1,0 +1,26 @@
+module Demo.Checkbox exposing (..)
+
+import Html exposing (Html, text)
+import Html.Attributes as Html
+import Mwc.Checkbox as Mwc exposing (checkbox, checkboxConfig)
+
+
+view =
+    Html.node "main"
+        []
+        [ Html.h3 [] [ text "Checkbox" ]
+        , checkbox checkboxConfig ""
+        , checkbox { checkboxConfig | checked = True } ""
+        , checkbox
+            { checkboxConfig
+                | indeterminate = True
+            }
+            ""
+        , checkbox
+            { checkboxConfig
+                | indeterminate = True
+                , additionalAttributes = [ Html.class "special" ]
+            }
+            ""
+        , checkbox { checkboxConfig | disabled = True } ""
+        ]

--- a/demo/Demo/Chips.elm
+++ b/demo/Demo/Chips.elm
@@ -1,0 +1,12 @@
+module Demo.Chips exposing (..)
+
+import Html exposing (Html, text)
+import Mwc.Chips as Mwc exposing (chip, chipConfig, chipSet, chipSetConfig)
+
+
+view =
+    Html.node "main"
+        []
+        [ Html.h3 [] [ text "Chips" ]
+        , chip chipConfig "example"
+        ]

--- a/demo/Demo/FloatingActionButton.elm
+++ b/demo/Demo/FloatingActionButton.elm
@@ -1,0 +1,33 @@
+module Demo.FloatingActionButton exposing (..)
+
+import Html exposing (Html, text)
+import Html.Attributes as Html
+import Mwc.Fab as Mwc exposing (fab, fabConfig)
+
+
+view =
+    Html.node "main"
+        []
+        [ Html.h3 [] [ text "FAB" ]
+        , Html.div
+            [ Html.class "demo-fab-group demo-group-spaced" ]
+            [ fab fabConfig "explore"
+            , fab
+                { fabConfig
+                    | additionalAttributes = [ Html.class "light" ]
+                }
+                "code"
+            , fab fabConfig "feedback"
+            , fab
+                { fabConfig
+                    | mini = True
+                    , additionalAttributes = [ Html.class "special" ]
+                }
+                "gavel"
+            , fab
+                { fabConfig
+                    | disabled = True
+                }
+                "fingerprint"
+            ]
+        ]

--- a/demo/Main.elm
+++ b/demo/Main.elm
@@ -1,7 +1,7 @@
 module Main exposing (..)
 
-import Button
-import Card
+import Demo.Button as Button
+import Demo.Card as Card
 import Html exposing (Html, text)
 import Html.Attributes as Html
 import Html.Events as Html

--- a/demo/Main.elm
+++ b/demo/Main.elm
@@ -1,13 +1,13 @@
 module Main exposing (..)
 
-import Demo.Button as Button
-import Demo.Card as Card
+import Demo.Button
+import Demo.Card
+import Demo.Checkbox
 import Html exposing (Html, text)
 import Html.Attributes as Html
 import Html.Events as Html
 import Mwc.Button as Mwc exposing (button, buttonConfig)
 import Mwc.Card as Card exposing (card, cardConfig)
-import Mwc.Checkbox as Mwc exposing (checkbox, checkboxConfig)
 import Mwc.Chips as Mwc exposing (chip, chipConfig, chipSet, chipSetConfig)
 import Mwc.Dialog as Mwc exposing (dialog, dialogConfig)
 import Mwc.Fab as Mwc exposing (fab, fabConfig)
@@ -25,11 +25,12 @@ main =
         [ Html.node "style"
             [ Html.type_ "text/css" ]
             [ text style
-            , text Button.style
-            , text Card.style
+            , text Demo.Button.style
+            , text Demo.Card.style
             ]
-        , Button.view
-        , Card.view
+        , Demo.Button.view
+        , Demo.Card.view
+        , Demo.Checkbox.view
         , Html.hr [] []
         , Html.h2 [] [ text "Material Web Components" ]
         , Html.h3 [] [ text "Button" ]
@@ -75,23 +76,6 @@ main =
                     | additionalAttributes = [ Html.class "special-icon" ]
                 }
                 "code"
-            ]
-        , Html.h3 [] [ text "Checkbox" ]
-        , Html.div
-            [ Html.class "group"
-            ]
-            [ checkbox checkboxConfig ""
-            , checkbox
-                { checkboxConfig
-                    | checked = True
-                }
-                ""
-            , checkbox
-                { checkboxConfig
-                    | indeterminate = True
-                    , additionalAttributes = [ Html.class "special" ]
-                }
-                ""
             ]
         , Html.h3 [] [ text "Radio" ]
         , Html.div

--- a/demo/Main.elm
+++ b/demo/Main.elm
@@ -3,14 +3,14 @@ module Main exposing (..)
 import Demo.Button
 import Demo.Card
 import Demo.Checkbox
+import Demo.Chips
+import Demo.FloatingActionButton
 import Html exposing (Html, text)
 import Html.Attributes as Html
 import Html.Events as Html
 import Mwc.Button as Mwc exposing (button, buttonConfig)
 import Mwc.Card as Card exposing (card, cardConfig)
-import Mwc.Chips as Mwc exposing (chip, chipConfig, chipSet, chipSetConfig)
 import Mwc.Dialog as Mwc exposing (dialog, dialogConfig)
-import Mwc.Fab as Mwc exposing (fab, fabConfig)
 import Mwc.FormField as Mwc exposing (formField, formFieldConfig)
 import Mwc.Icon as Mwc exposing (icon, iconConfig)
 import Mwc.IconToggle as Mwc exposing (iconToggle, iconToggleConfig)
@@ -31,6 +31,7 @@ main =
         , Demo.Button.view
         , Demo.Card.view
         , Demo.Checkbox.view
+        , Demo.FloatingActionButton.view
         , Html.hr [] []
         , Html.h2 [] [ text "Material Web Components" ]
         , Html.h3 [] [ text "Button" ]
@@ -44,22 +45,6 @@ main =
                 }
                 "Hi there"
             , button buttonConfig "I'm a button too"
-            ]
-        , Html.h3 [] [ text "Fab" ]
-        , Html.div
-            [ Html.class "group"
-            ]
-            [ fab fabConfig "map"
-            , fab
-                { fabConfig
-                    | additionalAttributes = [ Html.class "light" ]
-                }
-                "explore"
-            , fab
-                { fabConfig
-                    | additionalAttributes = [ Html.class "special" ]
-                }
-                "code"
             ]
         , Html.h3 [] [ text "Icon" ]
         , Html.div

--- a/demo/main.scss
+++ b/demo/main.scss
@@ -1,2 +1,6 @@
 @import "@material/theme/mdc-theme";
 @import "@material/card/mdc-card";
+
+.demo-fab-group{
+	width: 500px;
+}


### PR DESCRIPTION
Adds some basic modules for Demoing the following components:

- Checkbox
- FAB

Additionally, moves demos for components from `./demos/*` to `./demos/Demo/*` for namespacing under `./demos/Main.elm` and the like.

![2018-08-09 23_16_50-window](https://user-images.githubusercontent.com/1904543/43901610-3af7c9ca-9c2b-11e8-8d12-42aafc7a23a5.png)